### PR TITLE
TAKES-19 | TAKES-20 - Converted custom CSS components to use Tailwind instead

### DIFF
--- a/src/lib/components/ui/GetLocation/GetLocation.svelte
+++ b/src/lib/components/ui/GetLocation/GetLocation.svelte
@@ -7,31 +7,15 @@
 </script>
 
 <div>
-	<button class="getLocationButton" on:click={() => enableLocation()}>
+	<button
+		on:click={enableLocation}
+		class="flex items-center justify-center w-full h-[58px] rounded-lg bg-[#0892d2] text-white"
+	>
 		<img
 			src="https://res.cloudinary.com/du9tnv8ss/image/upload/v1756782708/navigation_bgtfde.png"
-			class="locationIcon"
 			alt=""
+			class="w-6 h-6 mr-2"
 		/>
-		Current Location</button
-	>
+		Current Location
+	</button>
 </div>
-
-<style>
-	.getLocationButton {
-		background-color: #0892d2;
-		height: 58px;
-		width: 100%;
-		border-radius: 8px;
-		display: flex;
-		flex-direction: center;
-		align-items: center;
-		justify-content: center;
-		color: #fff;
-	}
-	.locationIcon {
-		height: 24px;
-		width: 24px;
-		margin-right: 8px;
-	}
-</style>

--- a/src/lib/components/ui/GetLocation/GetLocation.svelte
+++ b/src/lib/components/ui/GetLocation/GetLocation.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { hasLocation } from '$lib/stores/global';
+	import { Button } from '$lib/components/ui/Button'
 
 	function enableLocation() {
 		hasLocation.set(true);
@@ -7,15 +8,15 @@
 </script>
 
 <div>
-	<button
-		on:click={enableLocation}
+	<Button 
+		onclick={() => {enableLocation()}}
 		class="flex items-center justify-center w-full h-[58px] rounded-lg bg-[#0892d2] text-white"
-	>
+	>		
 		<img
 			src="https://res.cloudinary.com/du9tnv8ss/image/upload/v1756782708/navigation_bgtfde.png"
 			alt=""
 			class="w-6 h-6 mr-2"
 		/>
 		Current Location
-	</button>
+	</Button>
 </div>

--- a/src/lib/components/ui/Header/Header.svelte
+++ b/src/lib/components/ui/Header/Header.svelte
@@ -1,23 +1,10 @@
-<section class="header">
+<section
+	class="flex items-center justify-center p-8 w-screen h-[72px] bg-white rounded-b-2xl z-50 md:justify-left
+	md:justify-start"
+>
 	<img
-		class="app-logo"
+		class="w-[218px]"
 		src="https://res.cloudinary.com/du9tnv8ss/image/upload/v1755893551/logo_dark_b1yskw.png"
 		alt="Take Shelter Now Logo"
 	/>
 </section>
-
-<style>
-	.header {
-		display: flex;
-		background-color: #fff;
-		width: 100vw;
-		height: 72px;
-		align-items: center;
-		justify-content: center;
-		border-bottom-left-radius: 16px;
-		border-bottom-right-radius: 16px;
-	}
-	.app-logo {
-		width: 218px;
-	}
-</style>

--- a/src/lib/components/ui/Sheet/Sheet.svelte
+++ b/src/lib/components/ui/Sheet/Sheet.svelte
@@ -1,58 +1,19 @@
-<div class="sheet">
-	<div class="handleContainer">
-		<div class="handle"></div>
+<div
+	class="fixed right-0 h-screen w-[400px] bg-white p-12 px-4 rounded-tl-2xl rounded-bl-2xl overflow-y-auto 
+           md:rounded-br-none md:rounded-tr-none
+           md:right-0 md:top-0
+           max-md:bottom-0 max-md:w-screen max-md:h-1/2 max-md:p-4 max-md:rounded-tr-2xl max-md:rounded-bl-none z-60"
+>
+	<!-- Handle only shows on mobile -->
+	<div class="hidden max-md:flex w-full justify-center items-center">
+		<div class="w-[60px] h-[4px] rounded-lg bg-gray-400 mb-4"></div>
 	</div>
-	<h1>Storm Shelters Near You</h1>
+
+	<h1 class="text-[22px] leading-[22px] font-extrabold text-left font-[DM_Sans] pb-4">
+		Storm Shelters Near You
+	</h1>
+
 	<div>
 		<slot></slot>
 	</div>
 </div>
-
-<style>
-	.sheet {
-		position: fixed;
-		right: 0px;
-		height: 100vh;
-		width: 30vw;
-		background-color: #fff;
-		padding: 48px 16px;
-		border-top-left-radius: 16px;
-		border-bottom-left-radius: 16px;
-		overflow-y: auto;
-	}
-
-	h1 {
-		font-size: 22px;
-		line-height: 22px;
-		font-weight: 800;
-		text-align: left;
-		font-family: 'DM Sans', sans-serif;
-		padding-bottom: 16px;
-	}
-
-	/* Mobile Styles */
-	@media (max-width: 768px) {
-		.sheet {
-			bottom: 0px;
-			width: 100vw;
-			height: 50vh;
-			padding: 16px 16px;
-			border-top-right-radius: 16px;
-			border-bottom-left-radius: 0px;
-		}
-		.handleContainer {
-			display: flex;
-			width: 100%;
-			align-content: center;
-			justify-content: center;
-		}
-		.handle {
-			width: 60px;
-			height: 4px;
-			border-radius: 8px;
-			align-self: center;
-			background-color: gray;
-			margin-bottom: 16px;
-		}
-	}
-</style>

--- a/src/lib/components/ui/ShelterCard/ShelterCard.svelte
+++ b/src/lib/components/ui/ShelterCard/ShelterCard.svelte
@@ -5,65 +5,22 @@
 	export let address: string = '423 East Central, Springfield, MO 65802';
 </script>
 
-<div class="card">
-	<div class="distance-view">
-		<p class="distance-number">{distance}</p>
-		<p class="miles-away">Miles Away</p>
-	</div>
-	<div class="text-view">
-		<h2>{title}</h2>
-		<p class="address-text">
-			{address}
+<div
+	class="flex flex-row rounded-2xl bg-[#f4f4f4] mb-4 shadow-md"
+>
+	<!-- Distance view -->
+	<div class="flex flex-col items-center justify-center text-center p-4">
+		<p class="font-[DM_Sans] text-[#c91c1c] text-[22px] leading-[18px] font-black">
+			{distance}
+		</p>
+		<p class="font-[DM_Sans] text-[#c91c1c] text-[6px] leading-[18px]">
+			Miles Away
 		</p>
 	</div>
 
-	<!-- <button on:click={increment}>Increment</button> -->
+	<!-- Text view -->
+	<div class="p-4">
+		<h2 class="text-[16px] font-extrabold">{title}</h2>
+		<p class="font-[DM_Sans] text-[12px] font-normal">{address}</p>
+	</div>
 </div>
-
-<style>
-	.card {
-		border-radius: 16px;
-		background-color: #f4f4f4;
-		/* border: 1px solid #ccc; */
-		margin-bottom: 16px;
-		display: flex;
-		flex-direction: row;
-		box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 22%);
-	}
-	.distance-view {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		text-align: center;
-		padding: 16px;
-	}
-	.distance-number {
-		font-family: 'DM Sans', sans-serif;
-		color: #c91c1c;
-		font-size: 22px;
-		line-height: 18px;
-		font-weight: 900;
-	}
-	.miles-away {
-		font-family: 'DM Sans', sans-serif;
-		color: #c91c1c;
-		font-size: 6px;
-		line-height: 18px;
-	}
-
-	h2 {
-		/* margin-bottom: 16px; */
-		font-size: 16px;
-		font-weight: 800;
-	}
-	.address-text {
-		font-family: 'DM Sans', sans-serif;
-		font-size: 12px;
-		font-weight: 400;
-	}
-
-	.text-view {
-		padding: 16px;
-	}
-</style>

--- a/src/lib/components/ui/ShelterList/ShelterList.svelte
+++ b/src/lib/components/ui/ShelterList/ShelterList.svelte
@@ -2,7 +2,7 @@
 	import { ShelterCard } from '$lib/components/ui/ShelterCard';
 </script>
 
-<div class="shelterList" id="shelter_list">
+<div class="pb-32 " id="shelter_list">
 	<ShelterCard />
 	<ShelterCard />
 	<ShelterCard />
@@ -11,8 +11,3 @@
 	<ShelterCard />
 </div>
 
-<style>
-	.shelterList {
-		padding-bottom: 128px;
-	}
-</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	import { hasLocation } from '$lib/stores/global';
 </script>
 
-<div class="container">
+<div class="relative h-screen overflow-hidden bg-[#e2e0e1] m-0">
 	<Header />
 	<Sheet>
 		{#if !$hasLocation}
@@ -16,13 +16,3 @@
 		{/if}
 	</Sheet>
 </div>
-
-<style>
-	.container {
-		height: 100vh;
-		overflow: hidden;
-		position: relative;
-		background-color: #e2e0e1;
-		margin: 0;
-	}
-</style>


### PR DESCRIPTION
Converted the Header, Sheet, ShelterCard, and GetLocation components to use Tailwind CSS. The style tags I originally wrote have been removed and replaced with Tailwind classes on each of the elements. I also shifted our GetLocations button to the ShadCN but I am just passing the style in as props. I will update the button component itself to match the designs soon and not require any additional classes to be passed in.